### PR TITLE
examples/aio_pika_server.py: Enable logging (and fix the warning)

### DIFF
--- a/examples/aio_pika_server.py
+++ b/examples/aio_pika_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import uuid
 
 import aio_pika
@@ -32,6 +33,7 @@ executor = integration.Executor('amqp://guest:guest@localhost:5672/v1', queue_na
 executor.dispatcher.add_methods(methods)
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     loop = asyncio.get_event_loop()
 
     loop.run_until_complete(executor.start())

--- a/pjrpc/server/integration/aio_pika.py
+++ b/pjrpc/server/integration/aio_pika.py
@@ -91,7 +91,7 @@ class Executor:
                             routing_key=reply_to,
                         )
 
-            message.ack()
+            await message.ack()
 
         except Exception as e:
             logger.exception("jsonrpc request handling error: %s", e)


### PR DESCRIPTION
To show warnings to be fixed in the aio_pika server, enable logging in `examples/aio_pika_server.py`:

This uncovers a missing `await` in `pjrpc/server/integration/aio_pika.py`:
```py
pjrpc/server/integration/aio_pika.py:103: \
RuntimeWarning: coroutine 'IncomingMessage.ack' was never awaited
  message.ack()
```
I push the fix for the warning in this pull request as a second commit.