### PR TITLE
Add an advanced aio_pika server example

### DIFF
--- a/examples/aio_pika_server_adv.py
+++ b/examples/aio_pika_server_adv.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+""" Advanced aio_pika server example:
+- uses functions which can be used as blueprints for larger examples
+- has an ExampleExecutor subclass to provide default settings for the Executor
+- sets up logging unless logging is already configured
+- support for strict typechecking using mypy --strict
+"""
+
+import asyncio
+import contextlib
+import logging
+from middleware_examples import log_requests
+from pjrpc.server import MethodRegistry
+from pjrpc.server.integration.aio_pika import Executor
+from typing import Any, Callable, List
+
+RpcMethods = List[Callable[..., Any]]
+
+
+def run_executor(
+    broker_url: str, queue_name: str, methods: RpcMethods, **kwargs: Any
+) -> None:
+    """Register the passed methods and run the server until it is stopped"""
+
+    executor = Executor(broker_url, queue_name, **kwargs)
+    registry = MethodRegistry()
+    for method in methods:
+        registry.add_methods(method)
+    executor.dispatcher.add_methods(registry)
+
+    # Everything is set up, now run the executor:
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(executor.start())
+    loop.run_forever()
+    with contextlib.suppress(RuntimeError):
+        loop.run_until_complete(executor.shutdown())
+
+
+def start_advanced_example_aio_pika_server() -> None:
+    """Register the example methods and run the server until it is stopped"""
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger()
+    calls = {"sum": 0}
+
+    def sum(a: int, b: int) -> int:
+        """RPC method for aio_pika_client.py's calls to sum(1, 2) -> 3"""
+        calls["sum"] += 1
+        return a + b
+
+    def tick() -> None:
+        """RPC method for examples/aio_pika_client.py's notification 'tick'"""
+        logger.info(f'run notification tick: sum called {calls["sum"]} times')
+
+    def shutdown() -> None:
+        """RPC method to terminate the server, for restart with updated code"""
+        asyncio.get_running_loop().stop()
+
+    run_executor(
+        "amqp://guest:guest@localhost:5672/v1",
+        "jsonrpc",
+        [sum, tick, shutdown],
+        middlewares=(log_requests(logger),),
+    )
+
+
+if __name__ == "__main__":
+    start_advanced_example_aio_pika_server()

--- a/examples/middleware_examples.py
+++ b/examples/middleware_examples.py
@@ -1,0 +1,23 @@
+import logging
+from pjrpc.common import Request
+from typing import Any, Callable
+
+RpcHandler = Callable[[Request, Any], Any]
+Middleware = Callable[[Request, RpcHandler, Any], Any]
+
+
+def log_requests(logger: logging.Logger) -> Middleware:
+    """Return a middleware as closure which using the given logger"""
+
+    async def mw(request: Request, context: Any, handler: RpcHandler) -> Any:
+        """PJRPC Middleware which logs the execution of called RPC methods"""
+
+        if request.is_notification:
+            logger.info(f"got notification {request.method}")
+            return await handler(request, context)
+        logger.info(f"got call {request.method}({request.params}):")
+        result = await handler(request, context)
+        logger.info(f"{request.method} returned {result}")
+        return result
+
+    return mw


### PR DESCRIPTION
Advanced aio_pika server example:
- uses functions which can be used as blueprints for larger examples
- has an ExampleExecutor subclass to provides default init values
- sets up logging unless logging is already configured
- support for strict typechecking using mypy --strict