### PR TITLE
Update aio-pika backend to aio-pika 8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- aio-pika integration and backend updated for aio-pika 8.0
 
 1.5.0 (2022-05-22)
 ------------------

--- a/examples/rabbitmq/aio_pika/client_response_queue.py
+++ b/examples/rabbitmq/aio_pika/client_response_queue.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""By default, RabbitMQ JSON-RPC clients generate a temporary result queue
+for their requests, but in very special cases, the client may want to choose
+a specific result queue.
+
+This example shows using a specific queue with specific properties as well."""
+import asyncio
+import logging
+
+from yarl import URL
+
+import pjrpc.client.backend.aio_pika
+
+
+async def client_with_specific_queue() -> None:
+    """aio_pika client demonstrating the use of a specific result_queue"""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    client = pjrpc.client.backend.aio_pika.Client(
+        broker_url=URL("amqp://guest:guest@localhost:5672/v1"),
+        queue_name="jsonrpc",
+        result_queue_name="pjrpc-aio_pika-example-jsonrpc-results",
+        result_queue_args={
+            "exclusive": True,
+            "auto_delete": True,
+            "durable": True,
+            "arguments": None,
+        },
+    )
+    await client.connect()
+
+    result = await client.proxy.sum(1, 2)
+    print(f"1 + 2 = {result}")
+
+    await client.notify("tick")
+    await client.notify("schedule_shutdown")
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(client_with_specific_queue())

--- a/pjrpc/server/integration/aio_pika.py
+++ b/pjrpc/server/integration/aio_pika.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, Optional
 
 import aio_pika
+from yarl import URL
 
 import pjrpc.server
 
@@ -18,15 +19,15 @@ class Executor:
     :param kwargs: dispatcher additional arguments
     """
 
-    def __init__(self, broker_url: str, queue_name: str, prefetch_count: int = 0, **kwargs: Any):
+    def __init__(self, broker_url: URL, queue_name: str, prefetch_count: int = 0, **kwargs: Any):
         self._broker_url = broker_url
         self._queue_name = queue_name
         self._prefetch_count = prefetch_count
 
         self._connection = aio_pika.connection.Connection(broker_url)
-        self._channel: Optional[aio_pika.Channel] = None
+        self._channel: Optional[aio_pika.abc.AbstractChannel] = None
 
-        self._queue: Optional[aio_pika.Queue] = None
+        self._queue: Optional[aio_pika.abc.AbstractQueue] = None
         self._consumer_tag: Optional[str] = None
 
         self._dispatcher = pjrpc.server.AsyncDispatcher(**kwargs)
@@ -65,7 +66,7 @@ class Executor:
 
         await self._connection.close()
 
-    async def _rpc_handle(self, message: aio_pika.IncomingMessage) -> None:
+    async def _rpc_handle(self, message: aio_pika.abc.AbstractIncomingMessage) -> None:
         """
         Handles JSON-RPC request.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-aio-pika = { version = "^6.8", optional = true }
+aio-pika = { version = "^8.0", optional = true }
 aiofiles = { version = "^0.7", optional = true }
 aiohttp = { version = "^3.7", optional = true }
 django = { version = "^3.0", optional = true }


### PR DESCRIPTION
aio-pika 7.0 and 8.0 have a number of improvements over aio-pika 6.8 which pjrpc currenty uses.

The changes to switch to 8.0 (or 7.0) are rather small:

Only the special case when a specific `result_queue_name` with 
`result_queue_args` needs an actual change, the remaining changes are only fixes for mypy type annotations for the type changes since aio-pika 7.0

Also add am example demonstrating the use of such specific result queue.