### PR TITLE
kombu client hanging bug fixed

### DIFF
--- a/pjrpc/client/backend/kombu.py
+++ b/pjrpc/client/backend/kombu.py
@@ -87,6 +87,7 @@ class Client(AbstractClient):
         )
 
         with kombu.Producer(self._connection) as producer:
+            result_queue.declare(channel=self._connection.default_channel)
             producer.publish(
                 request_text,
                 exchange=self._exchange or '',


### PR DESCRIPTION
**Reason:** kombu client creates a response queue implicitly after a request has been sent to the server. If the server finishes handling the request before the response queue is created then the response message will be lost. In such case the client hangs forever waiting for the response from the server.

**Solution:** This fix forces the client to create the response queue explicitly just before the request is sent which prevents the response message from being lost.