### PR TITLE
make init test: install extra-depends for test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 
 init:
 	pip install poetry --upgrade
-	poetry install --no-root
+	# Updates poetry.lock in case pyproject.toml was updated for install:
+	poetry update
+	poetry install --no-root --extras test
 
+export PYTHONWARNINGS=ignore::DeprecationWarning
 test:
 	poetry run py.test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ openapi-ui-bundles = ['openapi-ui-bundles']
 pydantic = ['pydantic']
 requests = ['requests']
 starlette = ['starlette', 'aiofiles']
+test = ['docstring-parser', 'flask', 'jsonschema', 'openapi-ui-bundles', 'pydantic', 'werkzeug']
 werkzeug = ['werkzeug']
 docgen = ['sphinx', 'aiohttp', 'aio-pika', 'flask', 'jsonschema', 'pydantic', 'requests', 'kombu']
 


### PR DESCRIPTION
`make init test` does not install the required packages for the test.

Fix this by defining the a `test` extra for `poetry` in `pyproject.toml` and add `--extras test` to `poetry install`.

In case `pyproject.toml` was updated, `poetry.lock` must be re-generated. Call `poetry update` to ensure that.

Silence deprecation warnings from `make test` by adding `export PYTHONWARNINGS=ignore::DeprecationWarning` to Makefile.