### PR TITLE
mypy: Type aliases for middlewares and update examples/middlewares.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 
 init:
 	pip install poetry --upgrade
-	poetry install --no-root
+	# Updates poetry.lock in case pyproject.toml was updated for install:
+	poetry update
+	poetry install --no-root --extras test
 
+export PYTHONWARNINGS=ignore::DeprecationWarning
 test:
 	poetry run py.test
 

--- a/examples/middlewares.py
+++ b/examples/middlewares.py
@@ -1,17 +1,23 @@
+from typing import Any
+
 from aiohttp import web
 
 import pjrpc.server
+from pjrpc.common import Request
 from pjrpc.server.integration import aiohttp
+from pjrpc.server.typedefs import AsyncHandlerType, ContextType, MiddlewareResponse
 
 methods = pjrpc.server.MethodRegistry()
 
 
 @methods.add(context='request')
-async def method(request):
+async def method(request: Any) -> None:
     print("method")
 
 
-async def middleware1(request, context, handler):
+async def middleware1(
+    request: Request, context: ContextType, handler: AsyncHandlerType,
+) -> MiddlewareResponse:
     print("middleware1 started")
     result = await handler(request, context)
     print("middleware1 finished")
@@ -19,7 +25,9 @@ async def middleware1(request, context, handler):
     return result
 
 
-async def middleware2(request, context, handler):
+async def middleware2(
+    request: Request, context: ContextType, handler: AsyncHandlerType,
+) -> MiddlewareResponse:
     print("middleware2 started")
     result = await handler(request, context)
     print("middleware2 finished")

--- a/pjrpc/server/typedefs.py
+++ b/pjrpc/server/typedefs.py
@@ -6,15 +6,37 @@ import pjrpc.common.exceptions
 from pjrpc.common import Request, Response, UnsetType
 
 __all__ = [
-    'AsyncMiddlewareType',
     'AsyncErrorHandlerType',
+    'AsyncMiddlewareType',
+    'AsyncHandlerType',
+    'MiddlewareResponse',
     'MiddlewareType',
     'ErrorHandlerType',
+    'ResponseOrUnset',
+    'ContextType',
 ]
 
+
+ContextType = Optional[Any]
+'''Context argument for RPC methods and middlewares'''  # for sphinx autodoc
+
+ResponseOrUnset = Union[UnsetType, Response]
+'''Return value of RPC handlers and middlewares'''  # for sphinx autodoc
+
+AsyncHandlerType = Callable[
+    [Request, Optional[Any]], Awaitable[ResponseOrUnset],
+]
+'''Async RPC handler method, passed to middlewares'''  # for sphinx autodoc
+
+HandlerType = Callable[[Request, Optional[Any]], ResponseOrUnset]
+'''Blocking RPC handler method, passed to middlewares'''  # for sphinx autodoc
+
+MiddlewareResponse = Union[UnsetType, Response]
+'''middlewares and handlers return Response or UnsetType'''  # for sphinx autodoc
+
 AsyncMiddlewareType = Callable[
-    [Request, Optional[Any], Callable[[Request, Optional[Any]], Union[UnsetType, Response]]],
-    Awaitable[Union[UnsetType, Response]],
+    [Request, ContextType, HandlerType],
+    Awaitable[MiddlewareResponse],
 ]
 '''Asynchronous middleware type'''  # for sphinx autodoc
 
@@ -26,8 +48,8 @@ AsyncErrorHandlerType = Callable[
 
 
 MiddlewareType = Callable[
-    [Request, Optional[Any], Callable[[Request, Optional[Any]], Union[UnsetType, Response]]],
-    Union[UnsetType, Response],
+    [Request, ContextType, HandlerType],
+    MiddlewareResponse,
 ]
 '''Synchronous middleware type'''  # for sphinx autodoc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ openapi-ui-bundles = ['openapi-ui-bundles']
 pydantic = ['pydantic']
 requests = ['requests']
 starlette = ['starlette', 'aiofiles']
+test = ['docstring-parser', 'flask', 'jsonschema', 'openapi-ui-bundles', 'pydantic', 'werkzeug']
 werkzeug = ['werkzeug']
 docgen = ['sphinx', 'aiohttp', 'aio-pika', 'flask', 'jsonschema', 'pydantic', 'requests', 'kombu']
 


### PR DESCRIPTION
Add type annotations for annotating RPC server middleware classes.

The 1st commit is submitted as #78 (fixes installing the test dependencies in `make init` for `make test`)