### PR TITLE
mypy fix

### DIFF
--- a/pjrpc/server/typedefs.py
+++ b/pjrpc/server/typedefs.py
@@ -23,25 +23,23 @@ ContextType = Optional[Any]
 ResponseOrUnset = Union[UnsetType, Response]
 '''Return value of RPC handlers and middlewares'''  # for sphinx autodoc
 
-AsyncHandlerType = Callable[
-    [Request, Optional[Any]], Awaitable[ResponseOrUnset],
-]
+AsyncHandlerType = Callable[[Request, ContextType], Awaitable[ResponseOrUnset]]
 '''Async RPC handler method, passed to middlewares'''  # for sphinx autodoc
 
-HandlerType = Callable[[Request, Optional[Any]], ResponseOrUnset]
+HandlerType = Callable[[Request, ContextType], ResponseOrUnset]
 '''Blocking RPC handler method, passed to middlewares'''  # for sphinx autodoc
 
 MiddlewareResponse = Union[UnsetType, Response]
 '''middlewares and handlers return Response or UnsetType'''  # for sphinx autodoc
 
 AsyncMiddlewareType = Callable[
-    [Request, ContextType, HandlerType],
+    [Request, ContextType, AsyncHandlerType],
     Awaitable[MiddlewareResponse],
 ]
 '''Asynchronous middleware type'''  # for sphinx autodoc
 
 AsyncErrorHandlerType = Callable[
-    [Request, Optional[Any], pjrpc.exceptions.JsonRpcError],
+    [Request, ContextType, pjrpc.exceptions.JsonRpcError],
     Awaitable[pjrpc.exceptions.JsonRpcError],
 ]
 '''Asynchronous server error handler'''  # for sphinx autodoc
@@ -54,7 +52,7 @@ MiddlewareType = Callable[
 '''Synchronous middleware type'''  # for sphinx autodoc
 
 ErrorHandlerType = Callable[
-    [Request, Optional[Any], pjrpc.exceptions.JsonRpcError],
+    [Request, ContextType, pjrpc.exceptions.JsonRpcError],
     pjrpc.exceptions.JsonRpcError,
 ]
 '''Synchronous server error handler'''  # for sphinx autodoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,3 +152,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "requests.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "yarl.*"
+ignore_missing_imports = true


### PR DESCRIPTION
- mypy ignore_missing_imports flag added for yarl library since its stubs are missing.
- middleware typesdefs fixed.