### PR TITLE
examples/aio_pika_server.py: Use asyncio.new_event_loop() for 3.10+ & mypy fixes

### DIFF
--- a/examples/aio_pika_server.py
+++ b/examples/aio_pika_server.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 
 import aio_pika
+from yarl import URL
 
 import pjrpc
 from pjrpc.server.integration import aio_pika as integration
@@ -11,13 +12,13 @@ methods = pjrpc.server.MethodRegistry()
 
 
 @methods.add
-def sum(a, b):
+def sum(a: int, b: int) -> int:
     """RPC method implementing examples/aio_pika_client.py's calls to sum(1, 2) -> 3"""
     return a + b
 
 
 @methods.add
-def tick():
+def tick() -> None:
     """RPC method implementing examples/aio_pika_client.py's notification 'tick'"""
     print("examples/aio_pika_server.py: received tick")
 
@@ -29,12 +30,14 @@ def add_user(message: aio_pika.IncomingMessage, user: dict):
     return {'id': user_id, **user}
 
 
-executor = integration.Executor('amqp://guest:guest@localhost:5672/v1', queue_name='jsonrpc')
+executor = integration.Executor(
+    broker_url=URL('amqp://guest:guest@localhost:5672/v1'), queue_name='jsonrpc'
+)
 executor.dispatcher.add_methods(methods)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
 
     loop.run_until_complete(executor.start())
     try:


### PR DESCRIPTION
### Hello @dapper91!

Note: To be merged before #90, but #90 includes this commit.

This is a trivial improvement to fix `mypy` warnings (except for `add_user()`, see #90 for it) in `examples/aio_pika_server.py`:

#### Details: 

If `asyncio.get_event_loop()` is called when there is no running event loop, Python 3.10+ warns:
```py
DeprecationWarning: There is no current event loop
```
https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop
> Because this function has rather complex behavior (especially when custom event loop policies are in use), using the [get_running_loop()](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop) function is preferred to [get_event_loop()](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) in coroutines and callbacks.
...
Deprecated since version 3.10: Deprecation warning is emitted if there is no running event loop. **In future Python releases, this function will be an alias of [get_running_loop()](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop).**

Because `examples/aio_pika_server.py` uses it to start the event loop, it must change in this way:
```py
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
```
Reference: https://stackoverflow.com/questions/71546992/asyncio-alternatives-to-deprecated-run-forever

While at it, also fix a few mypy errors in this example by adding type annotations and use yarl.URL as needed.