### PR TITLE
examples/aio_pika_server.py: Fix example add_user() to not trigger mypy

### DIFF
--- a/examples/aio_pika_server.py
+++ b/examples/aio_pika_server.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 
 import aio_pika
+from yarl import URL
 
 import pjrpc
 from pjrpc.server.integration import aio_pika as integration
@@ -11,13 +12,13 @@ methods = pjrpc.server.MethodRegistry()
 
 
 @methods.add
-def sum(a, b):
+def sum(a: int, b: int) -> int:
     """RPC method implementing examples/aio_pika_client.py's calls to sum(1, 2) -> 3"""
     return a + b
 
 
 @methods.add
-def tick():
+def tick() -> None:
     """RPC method implementing examples/aio_pika_client.py's notification 'tick'"""
     print("examples/aio_pika_server.py: received tick")
 
@@ -29,12 +30,14 @@ def add_user(message: aio_pika.IncomingMessage, user: dict):
     return {'id': user_id, **user}
 
 
-executor = integration.Executor('amqp://guest:guest@localhost:5672/v1', queue_name='jsonrpc')
+executor = integration.Executor(
+    broker_url=URL('amqp://guest:guest@localhost:5672/v1'), queue_name='jsonrpc'
+)
 executor.dispatcher.add_methods(methods)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
 
     loop.run_until_complete(executor.start())
     try:

--- a/examples/aio_pika_server.py
+++ b/examples/aio_pika_server.py
@@ -1,12 +1,30 @@
 import asyncio
 import logging
 import uuid
+from dataclasses import dataclass
 
 import aio_pika
 from yarl import URL
 
 import pjrpc
 from pjrpc.server.integration import aio_pika as integration
+
+
+@dataclass
+class UserInfo:
+    """User information dataclass for the add_user example RPC call"""
+
+    username: str
+    name: str
+    age: int
+
+
+@dataclass
+class AddedUser(UserInfo):
+    """User information dataclass (with uuid) for the add_user example RPC call"""
+
+    uuid: uuid.UUID
+
 
 methods = pjrpc.server.MethodRegistry()
 
@@ -24,10 +42,12 @@ def tick() -> None:
 
 
 @methods.add(context='message')
-def add_user(message: aio_pika.IncomingMessage, user: dict):
-    user_id = uuid.uuid4().hex
-
-    return {'id': user_id, **user}
+def add_user(message: aio_pika.IncomingMessage, user_info: UserInfo) -> AddedUser:
+    """Simluate the creation of a user: Receive user info and return it with an uuid4.
+    :param UserInfo user_info: user data
+    :returns: user_info with a randomly generated uuid4 added
+    :rtype: AddedUser"""
+    return AddedUser(**user_info.__dict__, uuid=uuid.uuid4())
 
 
 executor = integration.Executor(
@@ -37,6 +57,8 @@ executor.dispatcher.add_methods(methods)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
+    logging.info("Example result from a local call to add_user():")
+    logging.info(add_user(None, UserInfo("username", "firstname lastname", 18)))
     loop = asyncio.new_event_loop()
 
     loop.run_until_complete(executor.start())


### PR DESCRIPTION
### Hello!

This is a minor improvement to fix `mypy` of a currently not used RPC endpoint function in `examples/aio_pika_server.py`:

#### Details: 

The `add_user()` example in `examples/aio_pika_server.py`
is not yet used by the example client, so it can be fixed for `mypy`
using `dataclasses` similar to the example `add_user()`
with dataclasses at the end of README.rst:
https://github.com/dapper91/pjrpc/blob/master/README.rst#open-api-specification

```py
-def add_user(message: aio_pika.IncomingMessage, user: dict):
-    user_id = uuid.uuid4().hex
-
-    return {'id': user_id, **user}
+def add_user(message: aio_pika.IncomingMessage, user_info: UserInfo) -> AddedUser:
+    """Simluate the creation of a user: Receive user info and return it with an uuid4.
+    :param UserInfo user_info: user data
+    :returns: user_info with a randomly generated uuid4 added
+    :rtype: AddedUser"""
+    return AddedUser(**user_info.__dict__, uuid=uuid.uuid4())
```

@dapper91: The 1st commit of this branch is the commit from #89 as it's context depends on it.
It can be merged after (or instead of) #89.

It reduces the coverage percentage very slightly because the updated lines in the unused function is not yet covered. If this is approved or merged, a test case covering using RabbitMQ in the github actions:

- https://stackoverflow.com/questions/61678292/how-to-setup-rabbitmq-service-with-github-actions
- https://github.com/marketplace/actions/rabbitmq-in-github-actions
- http://www.thedreaming.org/2019/09/10/github-ci/