### PR TITLE
Fix AssertionErrors in close() of aio_pika client.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/pjrpc/client/backend/aio_pika.py
+++ b/pjrpc/client/backend/aio_pika.py
@@ -81,16 +81,16 @@ class Client(AbstractAsyncClient):
         Closes current broker connection.
         """
 
-        assert self._channel is not None, "client is not initialized"
-        assert self._connection is not None, "client is not initialized"
-        assert self._result_queue is not None, "client is not initialized"
-
-        if self._consumer_tag:
+        if self._consumer_tag and self._result_queue:
             await self._result_queue.cancel(self._consumer_tag)
             self._consumer_tag = None
 
-        await self._channel.close()
-        await self._connection.close()
+        if self._channel:
+            await self._channel.close()
+            self._channel = None
+        if self._connection:
+            await self._connection.close()
+            self._connection = None
 
         for future in self._futures.values():
             if future.done():


### PR DESCRIPTION
Issue #91 shows an AssertionError when a connected aio_pika client which didn't need to open a result queue calls client.close().

It should be possible to call client.close() also in this case to close the connection to the RabbitMQ server, because when either the client was interrupted, had nothing to do before closing, it, this is the normal state.

Also replace the other assertions in the aio_pika client's close() with simple checks which don't abort the function to close any other remaining connection elements or futures which are not properly handled when simply aborting with an assertion.

For details and a test case, see issue #91.