### PR TITLE
exclude_param validator / schema extractor feature

### DIFF
--- a/examples/aiohttp_dependency_injection.py
+++ b/examples/aiohttp_dependency_injection.py
@@ -1,0 +1,81 @@
+import uuid
+from typing import Any, Optional, Type
+
+import pydantic
+from aiohttp import web
+from dependency_injector import containers, providers
+from dependency_injector.wiring import Provide, inject
+
+import pjrpc.server
+import pjrpc.server.specs.extractors.pydantic
+from pjrpc.server.integration import aiohttp
+from pjrpc.server.specs import extractors
+from pjrpc.server.specs import openapi as specs
+from pjrpc.server.validators import pydantic as validators
+
+
+def is_di_injected(name: str, annotation: Type[Any], default: Any) -> bool:
+    return type(default) is Provide
+
+
+methods = pjrpc.server.MethodRegistry()
+validator = validators.PydanticValidator(exclude_param=is_di_injected)
+
+
+class UserService:
+    def __init__(self):
+        self._users = {}
+
+    def add_user(self, user: dict) -> str:
+        user_id = uuid.uuid4().hex
+        self._users[user_id] = user
+
+        return user_id
+
+    def get_user(self, user_id: uuid.UUID) -> Optional[dict]:
+        return self._users.get(user_id)
+
+
+class Container(containers.DeclarativeContainer):
+    wiring_config = containers.WiringConfiguration(modules=["__main__"])
+    user_service = providers.Factory(UserService)
+
+
+class User(pydantic.BaseModel):
+    name: str
+    surname: str
+    age: int
+
+
+@specs.annotate(summary='Creates a user', tags=['users'])
+@methods.add(context='request')
+@validator.validate
+@inject
+async def add_user(
+    request: web.Request,
+    user: User,
+    user_service: UserService = Provide[Container.user_service],
+) -> dict:
+    user_dict = user.model_dump()
+    user_id = user_service.add_user(user_dict)
+
+    return {'id': user_id, **user_dict}
+
+
+jsonrpc_app = aiohttp.Application(
+    '/api/v1',
+    specs=[
+        specs.OpenAPI(
+            info=specs.Info(version="1.0.0", title="User storage"),
+            schema_extractor=extractors.pydantic.PydanticSchemaExtractor(exclude_param=is_di_injected),
+            ui=specs.SwaggerUI(),
+        ),
+    ],
+)
+jsonrpc_app.dispatcher.add_methods(methods)
+jsonrpc_app.app['users'] = {}
+
+jsonrpc_app.app.container = Container()
+
+if __name__ == "__main__":
+    web.run_app(jsonrpc_app.app, host='localhost', port=8080)

--- a/pjrpc/server/typedefs.py
+++ b/pjrpc/server/typedefs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Optional, Union
+from typing import Any, Awaitable, Callable, Optional, Type, Union
 
 import pjrpc.common.exceptions
 from pjrpc.common import Request, Response, UnsetType
@@ -12,6 +12,7 @@ __all__ = [
     'MiddlewareResponse',
     'MiddlewareType',
     'ErrorHandlerType',
+    'ExcludeFunc',
     'ResponseOrUnset',
     'ContextType',
 ]
@@ -56,3 +57,7 @@ ErrorHandlerType = Callable[
     pjrpc.exceptions.JsonRpcError,
 ]
 '''Synchronous server error handler'''  # for sphinx autodoc
+
+
+ExcludeFunc = Callable[[str, Optional[Type[Any]], Optional[Any]], bool]
+'''Parameter exclude function'''  # for sphinx autodoc

--- a/pjrpc/server/validators/__init__.py
+++ b/pjrpc/server/validators/__init__.py
@@ -2,9 +2,10 @@
 JSON-RPC method parameters validators.
 """
 
-from .base import BaseValidator, ValidationError
+from .base import BaseValidator, ExcludeFunc, ValidationError
 
 __all__ = [
     'BaseValidator',
+    'ExcludeFunc',
     'ValidationError',
 ]

--- a/pjrpc/server/validators/base.py
+++ b/pjrpc/server/validators/base.py
@@ -1,9 +1,10 @@
 import functools as ft
 import inspect
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from pjrpc.common.typedefs import JsonRpcParams, MethodType
 from pjrpc.server import utils
+from pjrpc.server.typedefs import ExcludeFunc
 
 
 class ValidationError(Exception):
@@ -15,7 +16,13 @@ class ValidationError(Exception):
 class BaseValidator:
     """
     Base method parameters validator. Uses :py:func:`inspect.signature` for validation.
+
+    :param exclude_param: a function that decides if the parameters must be excluded
+                          from validation (useful for dependency injection)
     """
+
+    def __init__(self, exclude_param: Optional[ExcludeFunc] = None):
+        self._exclude_param = exclude_param or (lambda *args: False)
 
     def validate(self, maybe_method: Optional[MethodType] = None, **kwargs: Any) -> MethodType:
         """
@@ -73,7 +80,7 @@ class BaseValidator:
             raise ValidationError(str(e)) from e
 
     @ft.lru_cache(None)
-    def signature(self, method: MethodType, exclude: Tuple[str]) -> inspect.Signature:
+    def signature(self, method: MethodType, exclude: Tuple[str, ...]) -> inspect.Signature:
         """
         Returns method signature.
 
@@ -83,8 +90,10 @@ class BaseValidator:
         """
 
         signature = inspect.signature(method)
-        parameters = signature.parameters.copy()
-        for item in exclude:
-            parameters.pop(item, None)
 
-        return signature.replace(parameters=tuple(parameters.values()))
+        method_parameters: List[inspect.Parameter] = []
+        for param in signature.parameters.values():
+            if param.name not in exclude and not self._exclude_param(param.name, param.annotation, param.default):
+                method_parameters.append(param)
+
+        return signature.replace(parameters=method_parameters)

--- a/pjrpc/server/validators/jsonschema.py
+++ b/pjrpc/server/validators/jsonschema.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Iterable, Optional
 import jsonschema
 
 from pjrpc.common.typedefs import JsonRpcParams, MethodType
+from pjrpc.server.typedefs import ExcludeFunc
 
 from . import base
 
@@ -12,9 +13,12 @@ class JsonSchemaValidator(base.BaseValidator):
     Parameters validator based on `jsonschema <https://python-jsonschema.readthedocs.io/en/stable/>`_ library.
 
     :param kwargs: default jsonschema validator arguments
+    :param exclude_param: a function that decides if the parameters must be excluded
+                          from validation (useful for dependency injection)
     """
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, exclude_param: Optional[ExcludeFunc] = None, **kwargs: Any):
+        super().__init__(exclude_param=exclude_param)
         kwargs.setdefault('types', {'array': (list, tuple)})
         self.default_kwargs = kwargs
 

--- a/pjrpc/server/validators/pydantic.py
+++ b/pjrpc/server/validators/pydantic.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional
 import pydantic
 
 from pjrpc.common.typedefs import JsonRpcParams
+from pjrpc.server.typedefs import ExcludeFunc
 
 from . import base
 
@@ -16,9 +17,12 @@ class PydanticValidator(base.BaseValidator):
 
     :param coerce: if ``True`` returns converted (coerced) parameters according to parameter type annotation
                    otherwise returns parameters as is
+    :param exclude_param: a function that decides if the parameters must be excluded
+                          from validation (useful for dependency injection)
     """
 
-    def __init__(self, coerce: bool = True, **config_args: Any):
+    def __init__(self, coerce: bool = True, exclude_param: Optional[ExcludeFunc] = None, **config_args: Any):
+        super().__init__(exclude_param=exclude_param)
         self._coerce = coerce
 
         config_args.setdefault('extra', 'forbid')


### PR DESCRIPTION
- added `exclude_param` argument to be able to exclude a json-rpc parameter from validation and schema extraction.